### PR TITLE
修改 llvm url

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,9 +17,9 @@ jobs:
           submodules: false
       - name: prepare llvm
         run: |
+          pip install packaging
           python get_llvm_ps1.py ${{ matrix.version }} ${{ matrix.arch }}
           ./get_llvm_${{ matrix.version }}_${{ matrix.arch }}.ps1
-        timeout-minuts: 30
       - name: publish llvm to release
         uses: svenstaro/upload-release-action@v2
         with:

--- a/get_llvm_ps1.py
+++ b/get_llvm_ps1.py
@@ -1,6 +1,7 @@
 import sys
+from packaging.version import Version
 
-WIN32_PS1_SOURCE = """
+OLD_PS1_SOURCE = """
 New-Item -Path . -Name llvm-install -ItemType "directory"
 $InstallPath = (Resolve-Path -Path .\\llvm-install).Path
 
@@ -11,7 +12,7 @@ Remove-Item -Path $InstallPath\\Uninstall.exe
 Compress-Archive -Path $InstallPath\\* -DestinationPath .\\clang+llvm-{llvmver}-win{bits}.zip
 """
 
-WIN64_PS1_SOURCE = """
+NEW_PS1_SOURCE = """
 Invoke-WebRequest -Uri "https://github.com/llvm/llvm-project/releases/download/llvmorg-{llvmver}/clang+llvm-{llvmver}-x86_64-pc-windows-msvc.tar.xz" -OutFile "llvm.tar.xz"
 
 if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) {{
@@ -29,6 +30,9 @@ Remove-Item .\llvm.tar.xz
 Compress-Archive -Force -Path .\clang+llvm-{llvmver}-x86_64-pc-windows-msvc\\* -DestinationPath .\clang+llvm-{llvmver}-win{bits}.zip
 """
 
+def no_target(llvmver):
+    return Version(llvmver) < Version("18.1.0") or Version(llvmver) == Version("18.1.3")
+
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         print("Usage: python " + __file__ + " <version> <bits>")
@@ -40,6 +44,9 @@ if __name__ == '__main__':
 
     with open(f"get_llvm_{llvmver}_{bits}.ps1", "w") as f:
         if bits == "32":
-            f.write(WIN32_PS1_SOURCE.format(llvmver = llvmver, bits = bits))
+            f.write(OLD_PS1_SOURCE.format(llvmver = llvmver, bits = bits))
         elif bits == "64":
-            f.write(WIN64_PS1_SOURCE.format(llvmver = llvmver, bits = bits))
+            if no_target(llvmver):
+                f.write(OLD_PS1_SOURCE.format(llvmver = llvmver, bits = bits))
+            else:
+                f.write(NEW_PS1_SOURCE.format(llvmver = llvmver, bits = bits))


### PR DESCRIPTION
[llvm-project](https://github.com/llvm/llvm-project/releases) 只有 18.1.0 之后的版本才提供 clang+llvm-xx.x.x-x86_64-pc-windows-msvc.tar.xz，因此之前的版本只能用 LLVM-xx.x.x-win64.exe

在 18.1.0 之后的版本中，只有 18.1.3 没提供 clang+llvm-xx.x.x-x86_64-pc-windows-msvc.tar.xz，因此也使用 LLVM-xx.x.x-win64.exe

好消息：目前 [xmake-repo](https://github.com/xmake-io/xmake-repo) 最新的 llvm 只到 18.1.1，因此更新 llvm url 对现有的仓库配置影响很小

坏消息：使用 LLVM-xx.x.x-win64.exe 安装的 LLVM 内容非常不完整，几乎无法作为库使用（只有 15 个头文件）
![image](https://github.com/user-attachments/assets/bd49574b-8bcc-4434-b90c-30b92b3b39cc)

