### PR TITLE
更新 19.1.7

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         arch: ["32", "64"]
-        version: ["20.1.0"]
+        version: ["19.1.7"]
     runs-on: windows-latest
     steps:
       - name: checkout


### PR DESCRIPTION
当前 Release 的 19.1.7 版本来自 [LLVM-19.1.7-win64.exe](https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/LLVM-19.1.7-win64.exe)，内容不完整，无法作为库使用，改为从 [clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz](https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/clang+llvm-19.1.7-x86_64-pc-windows-msvc.tar.xz) 下载。

目前 Release 里已经有 19.1.7 了，所以 github action 会因为冲突而失败。合并之前可能需要先处理一下已有的 19.1.7 版本。