### PR TITLE
更新18.1.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         arch: ["32", "64"]
-        version: ["18.1.8"]
+        version: ["18.1.1"]
     runs-on: windows-latest
     steps:
       - name: checkout


### PR DESCRIPTION
将 release 里已有的 18.1.1 替换为更完整的版本。需要先处理 release 中已有的 18.1.1，否则 github action 会冲突失败。

由于 18.1.1 是 [xmake-repo](https://github.com/xmake-io/xmake-repo) 的最新版本，所以 xmake-repo 也需要同步更新，我在 xmake-repo 下提出了 [PR](https://github.com/xmake-io/xmake-repo/pull/6885)